### PR TITLE
Add macOS setup guide and simulation example

### DIFF
--- a/ProjectileSimulation.cpp
+++ b/ProjectileSimulation.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <cmath>
+
+const double g = 9.81; // Acceleration due to gravity (m/s^2)
+
+// Function to calculate the time of flight
+double timeOfFlight(double v0, double angle) {
+    double angleRad = (angle * M_PI) / 180; // Convert angle to radians
+    return (2 * v0 * sin(angleRad)) / g;
+}
+
+// Function to calculate maximum height
+double maxHeight(double v0, double angle) {
+    double angleRad = (angle * M_PI) / 180; // Convert angle to radians
+    return (pow(v0, 2) * pow(sin(angleRad), 2)) / (2 * g);
+}
+
+// Function to calculate range
+double range(double v0, double angle) {
+    double angleRad = (angle * M_PI) / 180; // Convert angle to radians
+    return (pow(v0, 2) * sin(2 * angleRad)) / g;
+}
+
+int main() {
+    double v0, angle;
+    std::cout << "Enter initial velocity (m/s): ";
+    std::cin >> v0;
+    std::cout << "Enter launch angle (degrees): ";
+    std::cin >> angle;
+
+    std::cout << "Time of Flight: " << timeOfFlight(v0, angle) << " seconds" << std::endl;
+    std::cout << "Maximum Height: " << maxHeight(v0, angle) << " meters" << std::endl;
+    std::cout << "Range: " << range(v0, angle) << " meters" << std::endl;
+
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# Enhanced Quick Start Guide for macOS Users
+
+This guide streamlines the setup process for running Euler simulations on macOS, incorporating best practices for installation and compatibility verification.
+
+## Step 1: Environment Setup
+
+Create a dedicated environment `eulerSimEnv` for dependency management.
+
+1. **Install Homebrew**:
+   - Ensure Homebrew is installed for managing packages.
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+2. **Install Python 3**:
+   - Use Homebrew to install the latest Python version.
+   ```bash
+   brew install python
+   ```
+
+3. **Create and Activate Virtual Environment**:
+   - Navigate to your project directory.
+   - Create `eulerSimEnv` and activate it.
+   ```bash
+   python3 -m venv eulerSimEnv
+   source eulerSimEnv/bin/activate
+   ```
+
+## Step 2: Compiler and Libraries
+
+Install a C++ compiler and necessary libraries.
+
+- **Xcode and Command Line Tools**:
+  - Install from the App Store and run:
+  ```bash
+  xcode-select --install
+  ```
+
+- **Eigen and HDF5**:
+  - Install using Homebrew.
+  ```bash
+  brew install hdf5
+  ```
+
+## Step 3: Validate Installation
+
+Ensure tools and libraries are correctly installed.
+
+- **Check Compiler**:
+  ```bash
+  g++ --version
+  ```
+
+- **Verify Python and Virtual Environment**:
+  ```bash
+  python --version
+  which python
+  ```
+
+- **Test Library Installation**:
+  - For HDF5:
+    ```bash
+    brew list | grep hdf5
+    ```
+
+## Running the Simulation
+
+After setup, compile and run a Euler simulation example.
+
+1. **Compile the Simulation**:
+   - Navigate to the simulation directory.
+   - Compile using `g++` (replace `YourSimulationFile.cpp` with your file):
+   ```bash
+   g++ -o EulerSimulation YourSimulationFile.cpp -I/usr/local/include -L/usr/local/lib -lhdf5
+   ```
+
+2. **Run the Simulation**:
+   ```bash
+   ./EulerSimulation
+   ```
+
+3. **Deactivate Environment** (when done):
+   ```bash
+   deactivate
+   ```
+
+## Automation Script
+
+For convenience, you can automate the setup and execution process using a script. Save the following as `setup_and_run.sh`:
+
+```bash
+#!/bin/bash
+
+# Install Homebrew, Python, and create a virtual environment
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install python
+python3 -m venv eulerSimEnv
+source eulerSimEnv/bin/activate
+
+# Install necessary tools and libraries
+xcode-select --install
+brew install hdf5
+
+# Compile and run the simulation
+g++ -o EulerSimulation main.cpp -I/usr/local/include -L/usr/local/lib -lhdf5
+./EulerSimulation
+
+# Deactivate the virtual environment
+deactivate
+```
+
+Make the script executable and run it:
+```bash
+chmod +x setup_and_run.sh
+./setup_and_run.sh
+```
+
+This script streamlines the entire process, from environment setup to running the simulation.
+
+
+Save the script in the root directory of your project where your simulation source files are located. This ensures that the script has direct access to the files it needs to compile and run. Here's how you can do this:
+
+1. Open Terminal on your macOS.
+2. Navigate to your project's root directory using the `cd` command. Replace `path/to/your/project` with the actual path to your project directory:
+   ```bash
+   cd path/to/your/project
+   ```
+3. Use the following command to create the script file directly in the terminal. It will open an editor in the terminal:
+   ```bash
+   nano setup_and_run.sh
+   ```
+4. Copy the script content provided in the previous response into the editor.
+5. Save the file by pressing `Ctrl + O`, then `Enter`, and exit the editor with `Ctrl + X`.
+
+To make the script executable and run it, use the following commands in the terminal while you are still in your project's root directory:
+
+```bash
+chmod +x setup_and_run.sh
+./setup_and_run.sh
+```
+
+This process places the script in the correct directory and ensures it has the necessary permissions to execute.

--- a/setup_and_run.sh
+++ b/setup_and_run.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Install Homebrew, Python, and create a virtual environment
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install python
+python3 -m venv eulerSimEnv
+source eulerSimEnv/bin/activate
+
+# Install necessary tools and libraries
+xcode-select --install
+brew install hdf5
+
+# Compile and run the simulation
+g++ -o EulerSimulation YourSimulationFile.cpp -I/usr/local/include -L/usr/local/lib -lhdf5
+./EulerSimulation
+
+# Deactivate the virtual environment
+deactivate


### PR DESCRIPTION
Implemented a comprehensive macOS setup guide, including environment setup, compiler installation, and necessary libraries. Added a basic simulation example file for quick start. 